### PR TITLE
Fix gcc-10 warnings about missing sentinel

### DIFF
--- a/src/XImlib2Caption.cpp
+++ b/src/XImlib2Caption.cpp
@@ -101,7 +101,7 @@ void XImlib2Caption::createFont()
                         XftTypeDouble,
                         (double)dIconConfig->getFontSize(), 
                         XFT_WEIGHT, XftTypeInteger, boldVal,
-                        NULL );
+                        (void *)NULL );
     
     XColor  screen, exact;
     if (!XAllocNamedColor (xContainer->getDisplay(), cmap, (char*)dIconConfig->getFontColor().c_str(), &screen, &exact))

--- a/src/XImlib2ToolTip.cpp
+++ b/src/XImlib2ToolTip.cpp
@@ -109,7 +109,7 @@ void XImlib2ToolTip::createFont()
 		 XftTypeDouble,
 		 (double)dConfig->getFontSizeTip(), 
 		 XFT_WEIGHT, XftTypeInteger, XFT_WEIGHT_MEDIUM,
-		 NULL );
+		 (void *)NULL );
 
     XftTextExtentsUtf8(display, tooltip.font, (XftChar8*)tipText.c_str(), tipText.length(), &fontInfo );
     


### PR DESCRIPTION
Tested while compiling on gcc-10 in Alpine Linux.
Now both files are fixed.